### PR TITLE
Changes to error messages

### DIFF
--- a/src/mujava/MutantsGenerator.java
+++ b/src/mujava/MutantsGenerator.java
@@ -362,6 +362,12 @@ public abstract class MutantsGenerator
          System.err.println( "File " + file + " not found." );
          return null;
       }
+      catch (UnsupportedClassVersionError e)
+      {
+	  System.err.println("Unable to use the OpenJava Parser because the class version is unsupported. It may be that the openjava.jar file was compiled with a version of Java later than the one you're using.");
+	  System.err.println();
+	  e.printStackTrace();
+      }
       
       CompilationUnit result;
       try

--- a/src/mujava/MutantsGenerator.java
+++ b/src/mujava/MutantsGenerator.java
@@ -365,8 +365,8 @@ public abstract class MutantsGenerator
       catch (UnsupportedClassVersionError e)
       {
 	  System.err.println("Unable to use the OpenJava Parser because the class version is unsupported. It may be that the openjava.jar file was compiled with a version of Java later than the one you're using.");
-	  System.err.println();
 	  e.printStackTrace();
+	  return null;
       }
       
       CompilationUnit result;
@@ -525,6 +525,13 @@ public abstract class MutantsGenerator
       // result = 0 : SUCCESS,   result = 1 : FALSE
       //int result = Main.compile(pars,new PrintWriter(new FileOutputStream("temp")));
          Main.compile(pars);
+      }
+      catch (NoClassDefFoundError e) {
+	  System.err.println("Could not compile the generated mutants. Make sure that tools.jar is in your classpath.");
+	  System.err.println("You may also need to delete the mutants that were generated (but not compiled) in the result/ directory of the muJava installation.");
+	  System.err.println();
+	  e.printStackTrace();
+	  System.exit(1);
       }
       catch (Exception e)
       {

--- a/src/mujava/MutantsGenerator.java
+++ b/src/mujava/MutantsGenerator.java
@@ -364,7 +364,8 @@ public abstract class MutantsGenerator
       }
       catch (UnsupportedClassVersionError e)
       {
-	  System.err.println("Unable to use the OpenJava Parser because the class version is unsupported. It may be that the openjava.jar file was compiled with a version of Java later than the one you're using.");
+	  System.err.println("[ERROR] Unable to use the OpenJava Parser because the class version is unsupported. It may be that the openjava.jar file was compiled with a version of Java later than the one you're using.");
+	  System.err.println();
 	  e.printStackTrace();
 	  return null;
       }
@@ -527,7 +528,7 @@ public abstract class MutantsGenerator
          Main.compile(pars);
       }
       catch (NoClassDefFoundError e) {
-	  System.err.println("Could not compile the generated mutants. Make sure that tools.jar is in your classpath.");
+	  System.err.println("[ERROR] Could not compile the generated mutants. Make sure that tools.jar is in your classpath.");
 	  System.err.println("You may also need to delete the mutants that were generated (but not compiled) in the result/ directory of the muJava installation.");
 	  System.err.println();
 	  e.printStackTrace();

--- a/src/mujava/MutationSystem.java
+++ b/src/mujava/MutationSystem.java
@@ -503,7 +503,7 @@ public class MutationSystem extends OJSystem
          } catch (ClassNotFoundException e)  
          {
             System.err.println(" Can't find the class: " + classes[i]);
-            System.err.println(" Please check CLASSPATH " );
+            System.err.println(" Please check that the compiled class for the code you want to mutate is in the classes/ directory. Also check that the MuJava_HOME variable in mujava.config does not end with a trailing slash. " );
 		    bad[i] = true; 
 		    classInfo[i] = new InheritanceINFO(classes[i], "");
             Runtime.getRuntime().exit(0);

--- a/src/mujava/MutationSystem.java
+++ b/src/mujava/MutationSystem.java
@@ -471,8 +471,8 @@ public class MutationSystem extends OJSystem
       
       if (classes == null)
       {
-         System.err.println("[ERROR] There is no classes to apply mutation.");
-         System.err.println(" Pleas check the directory  " + MutationSystem.CLASS_PATH);
+         System.err.println("[ERROR] There are no classes to mutate.");
+         System.err.println(" Please check the directory  " + MutationSystem.CLASS_PATH + " and be sure that MuJava_HOME is set correctly (without a trailing slash) in mujava.config.");
          Runtime.getRuntime().exit(0);
       }
       classInfo = new InheritanceINFO[classes.length];

--- a/src/mujava/MutationSystem.java
+++ b/src/mujava/MutationSystem.java
@@ -502,8 +502,8 @@ public class MutationSystem extends OJSystem
             }
          } catch (ClassNotFoundException e)  
          {
-            System.err.println(" Can't find the class: " + classes[i]);
-            System.err.println(" Please check that the compiled class for the code you want to mutate is in the classes/ directory. Also check that the MuJava_HOME variable in mujava.config does not end with a trailing slash. " );
+            System.err.println("[ERROR] Can't find the class: " + classes[i]);
+            System.err.println("Please check that the compiled class for the code you want to mutate is in the classes/ directory. Also check that the MuJava_HOME variable in mujava.config does not end with a trailing slash. " );
 		    bad[i] = true; 
 		    classInfo[i] = new InheritanceINFO(classes[i], "");
             Runtime.getRuntime().exit(0);
@@ -600,7 +600,7 @@ public class MutationSystem extends OJSystem
          TESTSET_PATH = home_path + "/testset";
       } catch (FileNotFoundException e1)
       {
-         System.err.println(" I can't find mujava.config file");
+         System.err.println("[ERROR] Can't find mujava.config file");
          e1.printStackTrace();
       } catch (Exception e)
       {
@@ -639,7 +639,7 @@ public class MutationSystem extends OJSystem
          TESTSET_PATH = home_path + "/testset";
       } catch (FileNotFoundException e1)
       {
-         System.err.println(" I can't find mujava.config file");
+         System.err.println("[ERROR] Can't find mujava.config file");
          e1.printStackTrace();
       } catch (Exception e)
       {

--- a/src/mujava/TestExecuter.java
+++ b/src/mujava/TestExecuter.java
@@ -178,7 +178,9 @@ public class TestExecuter {
           }
           reader.close();
         }catch(Exception e){
-          System.err.println("Error in update() in TraditioanlMutantsViewerPanel.java");
+          System.err.println("[WARNING] A problem occurred when running the traditional mutants:");
+	  System.err.println();
+	  e.printStackTrace();
         }
     }else{
       MutationSystem.MUTANT_PATH = original_mutant_path + "/" + methodSignature;
@@ -313,7 +315,7 @@ public class TestExecuter {
 	  catch (NoClassDefFoundError e) {
 	      System.err.println("Could not find one of the necessary classes for running tests. Make sure that .jar files for hamcrest and junit are in your classpath.");
 	      e.printStackTrace();
-	      break;
+	      return;
 	  }
        catch(Exception e){
     	   System.out.println(e.getMessage());

--- a/src/mujava/TestExecuter.java
+++ b/src/mujava/TestExecuter.java
@@ -310,6 +310,11 @@ public class TestExecuter {
 
       
       } 
+	  catch (NoClassDefFoundError e) {
+	      System.err.println("Could not find one of the necessary classes for running tests. Make sure that .jar files for hamcrest and junit are in your classpath.");
+	      e.printStackTrace();
+	      break;
+	  }
        catch(Exception e){
     	   System.out.println(e.getMessage());
     	   e.printStackTrace();

--- a/src/mujava/gui/GenMutantsMain.java
+++ b/src/mujava/gui/GenMutantsMain.java
@@ -66,7 +66,14 @@ public class GenMutantsMain extends JFrame
       MutationSystem.setJMutationStructure();
       MutationSystem.recordInheritanceRelation();
       GenMutantsMain main = new GenMutantsMain();
-      main.pack();
+      try {
+	  main.pack();
+      }
+      catch (NullPointerException e) {
+	  System.err.println("An error occurred while initializing muJava. This may have happened because the files used by muJava are in an unexpected state. Try deleting any uncompiled mutants that were generated in the result/ directory, and then re-generate them.");
+	  e.printStackTrace();
+	  return;
+      }
       main.setVisible(true);
    } 
 

--- a/src/mujava/gui/GenMutantsMain.java
+++ b/src/mujava/gui/GenMutantsMain.java
@@ -67,7 +67,8 @@ public class GenMutantsMain extends JFrame
 	  MutationSystem.setJMutationStructure();
       }
       catch (NoClassDefFoundError e) {
-	  System.err.println("Could not find one of the classes necessary to run muJava. Make sure that the .jar file for openjava is in your classpath.");
+	  System.err.println("[ERROR] Could not find one of the classes necessary to run muJava. Make sure that the .jar file for openjava is in your classpath.");
+	  System.err.println();
 	  e.printStackTrace();
 	  return;
       }
@@ -77,7 +78,8 @@ public class GenMutantsMain extends JFrame
 	  main.pack();
       }
       catch (NullPointerException e) {
-	  System.err.println("An error occurred while initializing muJava. This may have happened because the files used by muJava are in an unexpected state. Try deleting any uncompiled mutants that were generated in the result/ directory, and then re-generate them.");
+	  System.err.println("[ERROR] An error occurred while initializing muJava. This may have happened because the files used by muJava are in an unexpected state. Try deleting any uncompiled mutants that were generated in the result/ directory, and then re-generate them.");
+	  System.err.println();
 	  e.printStackTrace();
 	  return;
       }

--- a/src/mujava/gui/GenMutantsMain.java
+++ b/src/mujava/gui/GenMutantsMain.java
@@ -63,7 +63,14 @@ public class GenMutantsMain extends JFrame
    public static void main (String[] args) throws Exception 
    { 
       System.out.println("The main method starts");
-      MutationSystem.setJMutationStructure();
+      try {
+	  MutationSystem.setJMutationStructure();
+      }
+      catch (NoClassDefFoundError e) {
+	  System.err.println("Could not find one of the classes necessary to run muJava. Make sure that the .jar file for openjava is in your classpath.");
+	  e.printStackTrace();
+	  return;
+      }
       MutationSystem.recordInheritanceRelation();
       GenMutantsMain main = new GenMutantsMain();
       try {

--- a/src/mujava/gui/MutantsGenPanel.java
+++ b/src/mujava/gui/MutantsGenPanel.java
@@ -391,7 +391,7 @@ public class MutantsGenPanel extends JPanel
       String[] file_list = fTableModel.getSelectedFiles();
       if (file_list == null || file_list.length == 0)
       {
-         System.err.println("[ERROR] No class is selected.");
+         System.err.println("[ERROR] No class is selected. Please select one or more .java files for which you'd like to generate mutants.");
          return;
       }
       
@@ -405,7 +405,7 @@ public class MutantsGenPanel extends JPanel
       if ( (class_ops == null || class_ops.length == 0) && 
            (traditional_ops == null || traditional_ops.length == 0) )
       {
-         System.out.println("[Error] no operators is selected. "); 
+         System.out.println("[ERROR] No operators are selected. Please select one or more mutation operators."); 
          return;
       }
       


### PR DESCRIPTION
I've modified some of the error messages that occur when the user makes a mistake with the muJava configuration. I've also cleaned up some of the small grammar and spelling mistakes in the existing error messages.

Here are the errors that are now handled differently:

Generating mutants:
- MuJava_HOME is misconfigured and muJava cannot find class to mutate
- Using a version of Java older than what muJava was compiled with
- openjava.jar not in classpath
- tools.jar not in classpath
- Error that occurs when mutated versions cannot be compiled (because tools.jar is not in classpath) and then after fixing that problem, the state is unexpected because the mutated source exists but the compiled code does not
- Errors that occur when user does not choose class to mutate or does not choose type of mutations

Running mutants
- junit.jar not in classpath
- hamcrest.jar not in classpath

I will also modify the Wiki page with some related troubleshooting tips related to the "old" error messages.
